### PR TITLE
Start Envoy container with family-specific port bindings

### DIFF
--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -197,7 +197,14 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 		if port.Protocol != v1.ProtocolTCP && port.Protocol != v1.ProtocolUDP {
 			continue
 		}
-		args = append(args, fmt.Sprintf("--publish=%d:%d/%s", port.Port, port.Port, port.Protocol))
+
+		for _, family := range service.Spec.IPFamilies {
+			hostIP := "0.0.0.0"
+			if family == v1.IPv6Protocol {
+				hostIP = "[::]"
+			}
+			args = append(args, fmt.Sprintf("--publish=%s:%d:%d/%s", hostIP, port.Port, port.Port, port.Protocol))
+		}
 	}
 
 	args = append(args, image)


### PR DESCRIPTION
With the changes I'm making around port-forwards in Docker Desktop, I broke KinD integration. Those changes will make DD's behavior closer to what the Engine does.

Here's the issue:

- KinD creates a dual-stack `kind` network by default (eg. `docker run --ipv6=true --subnet=...`).
- When a `LoadBalancer` is created without `.spec.ipFamilyPolicy`, k8s assigns the first cluster IP it finds in `service-cluster-ip-range` (as documented in [1]). In our case, it's an IPv4 address.
- Then, `desktop-cloud-provider` creates an envoy container connected to that `kind` network and with `-p <port>:<target-port>`.
- Since there's no `HostIP` specified in that port binding, and the network is IPv6-capable, the Engine expands it into two different bindings: one for `0.0.0.0` and one for `::`.
- Then Docker Desktop detects these new port bindings and apply them on the host. With my changes, DD's port forwarder uses 'direct-routing' instead of hopping through the VM (ie. targetting the VM IP address).
- But since the `Service` isn't dual stack, `desktop-cloud-provider` configures Envoy to listen only on the IPv4 address `0.0.0.0` (see [2]). Because of that, the IPv6 port bound on the host by Docker Desktop targets an `<ipv6>:<port>` which is closed.

Before my changes, Docker Desktop was sending the port binding as-is too (ie. with no `HostIP`), but it'd then see two port-forwards:

- One with the HostIP `0.0.0.0`. It was converted into `::ffff:0.0.0.0` (I presume by mistake) and thus bound in dual-stack mode. It was pointing to VM's IPv4 address.
- One with the HostIP `::`, which was ignored as IPv6 wasn't supported.

This fix makes sure the Envoy container is created with port-bindings that match the address families of the `LoadBalancer`.

[1]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#dual-stack-options-on-new-services
[2]: https://github.com/docker/desktop-cloud-provider/blob/504acaf89a861e7c5752d799d86c17203758ba14/pkg/loadbalancer/proxy.go#L219