### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       -
         name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
## What

This Pull Request pins all GitHub Actions references in workflow files from mutable tags (e.g. `v4`, `latest`) to their corresponding **full-length commit SHAs**, with the original tag preserved as an inline comment for readability.

**Before:**
```yaml
uses: actions/checkout@v4
```

**After:**
```yaml
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
```

> [!IMPORTANT]
> No functional behavior changes — workflows will run the exact same action code as before.

## Why

Mutable tags (like `v4` or `latest`) can be force-pushed to point to a different commit at any time. Pinning to a full SHA ensures:

- **Supply chain integrity** — the exact code that runs in CI is immutable and auditable
- **Protection against tag hijacking** — a compromised upstream action can't silently inject malicious code via a tag update
- **Reproducible builds** — workflows always use the same action code regardless of upstream changes

> [!NOTE]
> Where mutable references were used (e.g. `v4`, `latest`), the SHA corresponds to the commit the reference pointed to on **April 16th, 2026 at 11:30 AM UTC**.

<details>
<summary><h2>How this was done</h2></summary>

Changes were generated automatically by the Docker security team using internal tooling that resolves each action tag to its corresponding commit SHA via the GitHub API and rewrites the workflow files.

Every third-party action used across the org has been individually security-reviewed before pinning.

</details>

## How to review

- [ ] Each `uses:` line now references a full 40-character SHA
- [ ] Pinned SHAs match the versions previously used
- [ ] Inline `# vX` comments match the original tags that were pinned

__Please feel free to edit this pull request !__

> [!WARNING]
> If anything looks incorrect or unexpected, or if you have questions, reach out to **#help-security** on Slack **before merging**.

---

> [!NOTE]
> If you need to update a pinned action in the future, update both the SHA **and** the inline comment.